### PR TITLE
docs: add maintenance freeze notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> **Maintenance freeze.** This repository is in maintenance freeze. No new contributions are accepted; no new releases will be cut without explicit approval from Georgian leadership.
+
 <!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
 <a name="readme-top"></a>
 <!--


### PR DESCRIPTION
## Summary

Adds a maintenance-freeze notice to the top of the README, per a Georgian leadership directive.

The repo stays public — but no new contributions or releases will land without explicit approval from Georgian leadership.

### Why

Existing OSS publications stay public-but-frozen as a deliberate choice: source already on the public internet for years cannot be retracted by flipping the repo private, and pulling published OSS would cost community trust without buying actual security. Freezing achieves the real goal (no new code ships publicly) while preserving the trust we extended to existing users.

### Reversibility

One-line revert if leadership later changes the policy for this repo specifically.

## Test plan

- [ ] Notice renders as a GitHub `[!IMPORTANT]` admonition at the top of the README on github.com
- [ ] No links / images / shields broken below the notice

Refs: internal Georgian tickets GDP-15 / GDP-16 / GDP-17.